### PR TITLE
Add Internet Archive to whitelist

### DIFF
--- a/OSINT.DigitalSide-Threat-Intel-Domain-WL.txt
+++ b/OSINT.DigitalSide-Threat-Intel-Domain-WL.txt
@@ -38,3 +38,4 @@ repository.eset.com
 assets-global.website-files.com
 vimeo.com
 i.ibb.co
+archive.org

--- a/misp-warning-list/OSINT.DigitalSide-Threat-Intel-Domain-WL.misp.json
+++ b/misp-warning-list/OSINT.DigitalSide-Threat-Intel-Domain-WL.misp.json
@@ -40,7 +40,8 @@
         "repository.eset.com",
         "assets-global.website-files.com",
         "vimeo.com",
-        "i.ibb.co"
+        "i.ibb.co",
+        "archive.org"
     ],
     "matching_attributes": [
         "hostname",
@@ -48,5 +49,5 @@
     ],
     "name": "OSINT.DigitalSide.IT WhiteList",
     "type": "hostname",
-    "version": "20231119174020"
+    "version": "20240418123947"
 }


### PR DESCRIPTION
Recent activity caused `web.archive.org` to be added, which seems very wrong.  
Support the Internet Archive and its mission
...this ads `archive.org` to the whitelist, which as i understand things should whitelist the archive, wayback machine, etc